### PR TITLE
Fix role-based dashboard redirects and header greeting

### DIFF
--- a/src/layouts/EmpleadoLayout.vue
+++ b/src/layouts/EmpleadoLayout.vue
@@ -24,7 +24,9 @@ function toggleSidebar() {
       class="flex flex-col flex-1 transition-all duration-300"
       :class="{ 'ml-64': !collapsed, 'ml-20': collapsed }"
     >
-      <TheHeader />
+      <TheHeader>
+        <template #title>Panel de Empleado</template>
+      </TheHeader>
       <main class="flex-1 p-6 md:p-8">
         <slot />
       </main>

--- a/src/layouts/TheHeader.vue
+++ b/src/layouts/TheHeader.vue
@@ -23,7 +23,7 @@ import { useAuthStore } from '@/stores/auth.store.js'
 const authStore = useAuthStore()
 const router = useRouter()
 
-const userName = computed(() => authStore.user?.name || 'Administrador')
+const userName = computed(() => authStore.user?.nombre || authStore.user?.name || 'Usuario')
 
 async function logout() {
   await authStore.logout()

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,8 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router';
-import { useAuthStore } from '@/stores/auth.store';
 import HomeView from '@/views/HomeView.vue';
 import LoginView from '@/views/LoginView.vue';
-import AdminDashboard from '@/views/admin/AdminDashboard.vue';
 import NotFoundView from '../views/NotFoundView.vue';
 import AccessDeniedView from '../views/AccessDeniedView.vue';
 
@@ -33,42 +31,6 @@ const routes = [
   ...adminRoutes,
   ...empleadoRoutes,
   ...colaboradorRoutes,
-  {
-    path: '/admin/dashboard',
-    name: 'AdminDashboard', // Nombre de ruta unificado
-    component: AdminDashboard,
-    meta: { requiresAuth: true, roles: ['administrador'] }
-  },
-  {
-    path: '/empleado/dashboard',
-    name: 'EmpleadoDashboard', // Nombre de ruta unificado
-    component: () => import('@/views/empleado/DashboardView.vue'),
-    meta: { requiresAuth: true, roles: ['empleado'] }
-  },
-  {
-    path: '/empleado/reservar',
-    name: 'ReservarActividad', // Asegúrate de que este nombre coincida con el del sidebar
-    component: () => import('@/views/empleado/ReservarActividadView.vue') // Corregido: Apunta al nombre de archivo correcto del componente.
-  },
-  {
-    path: '/empleado/mis-reservas',
-    name: 'MisReservas', // <-- AÑADIR ESTA RUTA
-    // Asumo que tendrás un componente para mostrar la lista de reservas.
-    // Si el archivo no existe, deberás crearlo.
-    component: () => import('@/views/empleado/MisReservasView.vue') 
-  },
-  {
-    path: '/superadmin/dashboard',
-    name: 'superadmin.dashboard',
-    component: () => import('@/views/superadmin/SuperAdminDashboard.vue'),
-    meta: { requiresAuth: true, roles: ['superadmin'] }
-  },
-  {
-    path: '/colaborador/dashboard',
-    name: 'colaborador.dashboard',
-    component: () => import('@/views/colaborador/ColaboradorDashboard.vue'),
-    meta: { requiresAuth: true, roles: ['colaborador'] }
-  },
   {
     path: '/:pathMatch(.*)*',
     name: 'not-found',
@@ -112,8 +74,18 @@ router.beforeEach(async (to, from, next) => {
     // Helper: destino home por rol
     const homeByRole = (user) => {
       if (!user) return { path: '/login' }
-      if (user.tipo_usuario === 'administrador') return { name: 'AdminDashboard' }
-      return { name: 'empleado-dashboard' }
+      switch (user.tipo_usuario) {
+        case 'administrador':
+          return { name: 'AdminDashboard' }
+        case 'empleado':
+          return { name: 'empleado-dashboard' }
+        case 'superadmin':
+          return { name: 'superadmin-dashboard' }
+        case 'colaborador':
+          return { name: 'colaborador-dashboard' }
+        default:
+          return { path: '/login' }
+      }
     }
 
     // 3) Reglas de acceso

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -94,9 +94,9 @@ async function handleSubmit() {
     // Mapa de redirección basado en roles y nombres de ruta
     const roleRedirectMap = {
       administrador: { name: 'AdminDashboard' },
-      empleado: { name: 'EmpleadoDashboard' },
-      superadmin: { name: 'superadmin.dashboard' }, // Asegúrate de que este nombre de ruta exista
-      colaborador: { name: 'colaborador.dashboard' } // Asegúrate de que este nombre de ruta exista
+      empleado: { name: 'empleado-dashboard' },
+      superadmin: { name: 'superadmin-dashboard' },
+      colaborador: { name: 'colaborador-dashboard' }
     };
 
     const redirectRoute = roleRedirectMap[userProfile.tipo_usuario];


### PR DESCRIPTION
## Summary
- Cleaned router configuration to rely on modular routes
- Redirect users to the proper dashboard based on role
- Display logged in user's name and employee-specific header title

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f9468c5b08330bd82f18e3588f74c